### PR TITLE
Restructure and Implement tokenize API

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,22 @@
 from fastapi import Depends, FastAPI, Header, HTTPException
 from routers import tag, tokenize
 
-app = FastAPI()
+DESC_TEXT = "Pythainlp API"
+
+app = FastAPI(
+    title='Pythainlp API',
+    description=DESC_TEXT,
+    version='0.1',
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 
 @app.get("/")

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from routers import tag, tokenize
+import pythainlp
 
 DESC_TEXT = "Pythainlp API"
 
@@ -20,8 +21,8 @@ app.add_middleware(
 )
 
 @app.get("/")
-def hello():
-    return {"Hello": "World"}
+def home():
+    return {"Pythainlp Version": pythainlp.__version__}
 
 
 app.include_router(tag.router, prefix="/tag", tags=["Tag"])

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ app.add_middleware(
 )
 
 @app.get("/")
-def home():
+def index():
     return {"Pythainlp Version": pythainlp.__version__}
 
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from routers import tag, tokenize
 
 DESC_TEXT = "Pythainlp API"
@@ -18,12 +19,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
-
 @app.get("/")
 def hello():
     return {"Hello": "World"}
 
 
-app.include_router(tag.router)
-app.include_router(tokenize.router)
+app.include_router(tag.router, prefix="/tag", tags=["Tag"])
+app.include_router(tokenize.router, prefix="/tokenize", tags=["Tokenize"])

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.get("/")
 def index():
     return {"Pythainlp Version": pythainlp.__version__}

--- a/routers/tokenize.py
+++ b/routers/tokenize.py
@@ -41,21 +41,21 @@ class SubwordTokenizeResponse(BaseModel):
     subwords: List[str] = []
 
 
-@router.get('/sent_tokenize', response_model=SentTokenizeResponse)
+@router.get('/sent', response_model=SentTokenizeResponse)
 def sent_tokenize(q: str, engine: SentTokenizeEngine = "whitespace"):
     return {"sents": tokenize.sent_tokenize(q, engine=engine)}
 
 
-@router.get('/word_tokenize', response_model=WordTokenizeResponse)
+@router.get('/word', response_model=WordTokenizeResponse)
 def word_tokenize(q: str, engine: WordTokenizeEngine = "newmm"):
     return {"words": tokenize.word_tokenize(q, engine=engine)}
 
 
-@router.get('/syllable_tokenize', response_model=SyllableTokenizeResponse)
+@router.get('/syllable', response_model=SyllableTokenizeResponse)
 def syllable_tokenize(q: str):
     return {"syllables": tokenize.syllable_tokenize(q)}
 
 
-@router.get('/subword_tokenize', response_model=SubwordTokenizeResponse)
+@router.get('/subword', response_model=SubwordTokenizeResponse)
 def subword_tokenize(q: str, engine: SubwordTokenizeEngine = "tcc"):
     return {"subwords": tokenize.subword_tokenize(q, engine=engine)}

--- a/routers/tokenize.py
+++ b/routers/tokenize.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter
 from pythainlp import tokenize
 from enum import Enum
+from typing import List, Optional
+from pydantic import BaseModel
 
 router = APIRouter()
+
 
 class TokenizeEngine(str, Enum):
     newmm = "newmm"
@@ -11,6 +14,11 @@ class TokenizeEngine(str, Enum):
     icu = "icu"
     ulmfit = "ulmfit"
 
-@router.get('/word_tokenize')
+
+class WordTokenizeResponse(BaseModel):
+    words: List[str] = []
+
+
+@router.get('/word_tokenize', response_model=WordTokenizeResponse)
 def word_tokenize(q: str, engine: TokenizeEngine = "newmm"):
-    return '|'.join(tokenize.word_tokenize(q,engine=engine))
+    return {"words": tokenize.word_tokenize(q, engine=engine)}

--- a/routers/tokenize.py
+++ b/routers/tokenize.py
@@ -1,10 +1,16 @@
 from fastapi import APIRouter
 from pythainlp import tokenize
+from enum import Enum
 
 router = APIRouter()
 
-@router.get('/tokenize/word_tokenize', tags=["tokenize"])
-def word_tokenize(q: str, engine: str = None):
-    if engine == None:
-        engine='newmm'
+class TokenizeEngine(str, Enum):
+    newmm = "newmm"
+    longest = "longest"
+    deepcut = "deepcut"
+    icu = "icu"
+    ulmfit = "ulmfit"
+
+@router.get('/word_tokenize')
+def word_tokenize(q: str, engine: TokenizeEngine = "newmm"):
     return '|'.join(tokenize.word_tokenize(q,engine=engine))

--- a/routers/tokenize.py
+++ b/routers/tokenize.py
@@ -7,7 +7,12 @@ from pydantic import BaseModel
 router = APIRouter()
 
 
-class TokenizeEngine(str, Enum):
+class SentTokenizeEngine(str, Enum):
+    whitespace = "whitespace"
+    whitespace_newline = "whitespace+newline"
+
+
+class WordTokenizeEngine(str, Enum):
     newmm = "newmm"
     longest = "longest"
     deepcut = "deepcut"
@@ -15,10 +20,42 @@ class TokenizeEngine(str, Enum):
     ulmfit = "ulmfit"
 
 
+class SubwordTokenizeEngine(str, Enum):
+    tcc = "tcc"
+    etcc = "etcc"
+
+
+class SentTokenizeResponse(BaseModel):
+    sents: List[str] = []
+
+
 class WordTokenizeResponse(BaseModel):
     words: List[str] = []
 
 
+class SyllableTokenizeResponse(BaseModel):
+    syllables: List[str] = []
+
+
+class SubwordTokenizeResponse(BaseModel):
+    subwords: List[str] = []
+
+
+@router.get('/sent_tokenize', response_model=SentTokenizeResponse)
+def sent_tokenize(q: str, engine: SentTokenizeEngine = "whitespace"):
+    return {"sents": tokenize.sent_tokenize(q, engine=engine)}
+
+
 @router.get('/word_tokenize', response_model=WordTokenizeResponse)
-def word_tokenize(q: str, engine: TokenizeEngine = "newmm"):
+def word_tokenize(q: str, engine: WordTokenizeEngine = "newmm"):
     return {"words": tokenize.word_tokenize(q, engine=engine)}
+
+
+@router.get('/syllable_tokenize', response_model=SyllableTokenizeResponse)
+def syllable_tokenize(q: str):
+    return {"syllables": tokenize.syllable_tokenize(q)}
+
+
+@router.get('/subword_tokenize', response_model=SubwordTokenizeResponse)
+def subword_tokenize(q: str, engine: SubwordTokenizeEngine = "tcc"):
+    return {"subwords": tokenize.subword_tokenize(q, engine=engine)}


### PR DESCRIPTION
### What does this changes

- Return Pythainlp version on index page
- Add CORSMiddleware
- Changes way to  include_router
- Add API For sent_tokenize, syllable_tokenize and subword_tokenize
- Add Response model
- Add Engine model

### Todo 

-  Implement unit test for tokenize